### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/bin/add_definition.dart
+++ b/bin/add_definition.dart
@@ -65,8 +65,9 @@ void main(List<String> args) async {
       exit(3);
     }
 
-    final lineStream =
-        file.openRead().transform(utf8.decoder).transform(LineSplitter());
+    final lineStream = utf8.decoder
+        .bind(file.openRead())
+        .transform(LineSplitter());
     final targetLine = int.tryParse(argResult.rest[2]);
     if (targetLine == null) {
       print('Provide a valid line number as third argument.');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cucumber_wire
 description: Write cucumber test definitions in dart and run them using the cucumber wire protocol.
-version: 0.1.0
+version: 0.1.0+1
 author: Eric Schneller <eric@schnellers.name>
 homepage: https://github.com/eredo/cucumber_wire
 


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900